### PR TITLE
add locks on changing models

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ uvicorn~=0.18.3
 fastapi~=0.85.1
 pydantic~=1.9.2
 starlette~=0.20.4
+fastapi-cache2[redis]==0.1.9
 
 torch==1.12 # keep torch at the bottom of the list to allow canceling in case of 
 # cuda mismatch


### PR DESCRIPTION
Added `_models_lock`: `asyncio.Lock` as a private field to `ModelState` singleton. The lock is acquired/released when loading qa/qg models.